### PR TITLE
Fixed title color for dark Xfwm themes

### DIFF
--- a/xfwm4/src/Stilo-dark/themerc
+++ b/xfwm4/src/Stilo-dark/themerc
@@ -9,7 +9,7 @@ title_vertical_offset_inactive=0
 
 #button_layout=O|HMC
 
-active_text_color=#3C3C3C
+active_text_color=#FFFFFF
 inactive_text_color=#8f8f8f
 #inactive_text_shadow_color=#444240
 

--- a/xfwm4/src/Stiloetto-dark/themerc
+++ b/xfwm4/src/Stiloetto-dark/themerc
@@ -9,7 +9,7 @@ title_vertical_offset_inactive=0
 
 #button_layout=O|HMC
 
-active_text_color=#3C3C3C
+active_text_color=#FFFFFF
 inactive_text_color=#8f8f8f
 #inactive_text_shadow_color=#444240
 


### PR DESCRIPTION
Hi Mattias, awesome theme! I'm using it on my Xubuntu 19.04 and I noticed that window title is very dark on active windows on dark Xfwm themes. It's a simple fix. I chose #FFFFFF because window buttons are in the same color.